### PR TITLE
🐛 Fix client deployment

### DIFF
--- a/frontend/OdethMagia/Dockerfile
+++ b/frontend/OdethMagia/Dockerfile
@@ -7,7 +7,7 @@ RUN npm install
 RUN npm install -g @angular/cli
 COPY . .
 #Como corres tu app
-CMD ["ng", "serve", "-o"]
+CMD ["ng", "serve", "--host=0.0.0.0", "--disable-host-check"]
 
 
 

--- a/frontend/OdethMagia/angular.json
+++ b/frontend/OdethMagia/angular.json
@@ -12,7 +12,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "baseHref": "/myApp/",
+            "baseHref": "/",
             "outputPath": "dist/odeth-magia",
             "index": "src/index.html",
             "main": "src/main.ts",

--- a/frontend/OdethMagia/angular.json
+++ b/frontend/OdethMagia/angular.json
@@ -8,25 +8,18 @@
       "schematics": {},
       "root": "",
       "sourceRoot": "src",
-      "prefix": "app",
       "architect": {
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
+            "baseHref": "/myApp/",
             "outputPath": "dist/odeth-magia",
             "index": "src/index.html",
             "main": "src/main.ts",
-            "polyfills": [
-              "zone.js"
-            ],
+            "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": []
           },
           "configurations": {
@@ -77,18 +70,10 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": [
-              "zone.js",
-              "zone.js/testing"
-            ],
+            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "tsconfig.spec.json",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": []
           }
         }

--- a/infra/k8s/ingress-srv.yml
+++ b/infra/k8s/ingress-srv.yml
@@ -24,7 +24,7 @@ spec:
                 name: admin-srv
                 port:
                   number: 3000
-          - path: /myApp
+          - path: /
             pathType: Prefix
             backend:
               service:

--- a/infra/k8s/ingress-srv.yml
+++ b/infra/k8s/ingress-srv.yml
@@ -24,7 +24,7 @@ spec:
                 name: admin-srv
                 port:
                   number: 3000
-          - path: /?(.*)
+          - path: /myApp
             pathType: Prefix
             backend:
               service:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -8,14 +8,13 @@ build:
   local:
     push: false
   artifacts:
-
     - image: magiavidencia/user-dashboard
       context: frontend/OdethMagia
       docker:
         dockerfile: Dockerfile
       sync:
         manual:
-          - src: "**/*"
+          - src: "src/*"
             dest: .
     - image: magiavidencia/auth-courses
       context: backend/auth


### PR DESCRIPTION
Fixes the Client deployment
The --disable-host-check option is used with the ng serve command in Angular. When you use this option, it disables the host check process. This means that the development server will accept requests from any host.
This can be useful in certain development scenarios where you want to access your application from a different device or from a different domain. For example, if you want to access your Angular application from an external network or from a mobile device for testing, you might need to disable the host check.
Here's how you can use it:

ng serve --host 0.0.0.0 --disable-host-check

In this command, --host 0.0.0.0 allows connections from any IP address, and --disable-host-check disables the host check process.
Please note that this option should be used carefully, as it could potentially expose your development server to outside networks. It's generally recommended to use this option only in a secure and controlled development environment.
